### PR TITLE
feat/fix-docs: Fix wrong apiVersion on the example CRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ helm install zap-operator nccloud/zap-operator
 Create a `ZapScan` resource to run a one-time security scan:
 
 ```yaml
-apiVersion: zap.spaceship.com/v1alpha1
+apiVersion: spaceship.com/v1alpha1
 kind: ZapScan
 metadata:
   name: example-scan
@@ -43,7 +43,7 @@ spec:
 Create a `ZapScheduledScan` resource to run scans on a schedule:
 
 ```yaml
-apiVersion: zap.spaceship.com/v1alpha1
+apiVersion: spaceship.com/v1alpha1
 kind: ZapScheduledScan
 metadata:
   name: nightly-scan


### PR DESCRIPTION
<!-- Describe the purpose of the PR -->

## What does this change resolve?

There was an difference on applied CRD definitions with helm and examples on documentations. That's way I fix the apiversion of the example contents.

## Open questions or TODOs before merging if any

<!-- - [ ] Use github checklists. When solved, check the box -->
